### PR TITLE
chore: upadate auth service volume and network names

### DIFF
--- a/src/docker/production/ec2_deploy.sh
+++ b/src/docker/production/ec2_deploy.sh
@@ -3,8 +3,12 @@
 set -o errexit 
 set -o nounset 
 
+# TODO ProStream EC2 server has been used to deploy the project. 
+#  Make sure the Environment variables are properly exported in the HOST Machine. 
+
+
 # Export the variables in the host machine. 
-if [[ -z "${AUTH_CODE_MANAGER_EC2_SERVER_IP_ADDRESS}" ]]; then
+if [[ -z "${PROSTREAM_ALGO_AUTH_EC2_IP_ADDR}" ]]; then
     echo "EC2 Server IP Address for Auth and Code Manager Service is not defined."
     echo "Please export the EC2 server IP address in host machine and try again."
     exit 1
@@ -19,13 +23,13 @@ git archive --format tar --output ./production_project.tar main
 
 echo "Uploading the Project to the server ... " 
 
-rsync -e "ssh -i ${AUTH_CODE_MANAGER_EC2_SERVER_PEM_PATH}" ./production_project.tar ubuntu@"${AUTH_CODE_MANAGER_EC2_SERVER_IP_ADDRESS}":/tmp/production_project.tar
+rsync -e "ssh -i ${PROSTREAM_ALGO_AUTH_EC2_PEM}" ./production_project.tar ubuntu@"${PROSTREAM_ALGO_AUTH_EC2_IP_ADDR}":/tmp/production_project.tar
 
 echo "Upload complete ... "
 
 echo "Building the docker compose  ... "
 
-ssh -i "${AUTH_CODE_MANAGER_EC2_SERVER_PEM_PATH}" -o StrictHostKeyChecking=no ubuntu@"${AUTH_CODE_MANAGER_EC2_SERVER_IP_ADDRESS}" << 'ENDSSH'
+ssh -i "${PROSTREAM_ALGO_AUTH_EC2_PEM}" -o StrictHostKeyChecking=no ubuntu@"${PROSTREAM_ALGO_AUTH_EC2_IP_ADDR}" << 'ENDSSH'
 
     PROJECT_PATH=/home/ubuntu/algocode-auth-service/backend 
     LOG_PATH=/home/ubuntu/algocode-auth-service/logs

--- a/src/production.yml
+++ b/src/production.yml
@@ -7,8 +7,8 @@ services:
       dockerfile: ./docker/production/django/Dockerfile
     image: api-image
     volumes: 
-      - static_volume:/app/staticfiles
-      - media_volume:/app/mediafiles 
+      - algocode_production_auth_static_volume:/app/staticfiles
+      - algocode_production_auth_media_volume:/app/mediafiles 
     env_file: 
       - ./.envs/.production/.django
       - ./.envs/.production/.postgres
@@ -17,7 +17,7 @@ services:
       - redis-for-celery
     command: /start  
     networks: 
-      - algocode-backend-auth-service-network
+      - algocode-production-auth-service-network
 
   postgres: 
     build: 
@@ -25,49 +25,49 @@ services:
       dockerfile: ./docker/production/postgres/Dockerfile
     image: pg-image
     volumes: 
-      - production_postgres_data:/var/lib/postgresql/data
-      - production_postgres_data_backups:/backups
+      - algocode_production_auth_production_postgres_data:/var/lib/postgresql/data
+      - algocode_production_auth_production_postgres_data_backups:/backups
     env_file: 
       - ./.envs/.production/.postgres 
     networks: 
-      - algocode-backend-auth-service-network
+      - algocode-production-auth-service-network
 
     
   redis-for-celery: 
     image: redis:7-alpine
     networks: 
-      - algocode-backend-auth-service-network
+      - algocode-production-auth-service-network
 
   celery_worker:   # using anchor of api service. 
     <<: *api 
     image: celery-image
     command: /start-celeryworker
     networks: 
-      - algocode-backend-auth-service-network
+      - algocode-production-auth-service-network
     
   flower: 
     <<: *api 
     image: flower-image
     command: /start-flower
     volumes: 
-      - flower_data:/data
+      - algocode_production_auth_flower_data:/data
     ports: 
       - "5555:5555"
     networks: 
-      - algocode-backend-auth-service-network
+      - algocode-production-auth-service-network
     
 
 # TODO create the network in the server. 
 networks: 
-  algocode-backend-auth-service-network: 
+  algocode-production-auth-service-network: 
     external: true 
   
 
 volumes: 
-  static_volume: {}
-  media_volume: {}
-  production_postgres_data: {}
-  production_postgres_data_backups: {}
-  flower_data: {}
+  algocode_production_auth_static_volume: {}
+  algocode_production_auth_media_volume: {}
+  algocode_production_auth_production_postgres_data: {}
+  algocode_production_auth_production_postgres_data_backups: {}
+  algocode_production_auth_flower_data: {}
   
   

--- a/src/proxy-manager-portainer.yml
+++ b/src/proxy-manager-portainer.yml
@@ -3,7 +3,8 @@
 # docker compose for nginx reverse proxy and portainer. see nginx reverse proxy documentation for more advanced settings.  
 # create the network if already not created. 
 # copy the compose file in the specified dir in the server, and then run the compose file. 
-# docker compose -p algocode_auth_service_monitor -f production.yml up -d --remove-orphans 
+# docker compose -p algocode_auth_service_monitor -f proxy-manager-portainer.yml up -d --remove-orphans 
+# NOTE: put the correct compose file name after -f flag. 
 
 services:
   app:


### PR DESCRIPTION
* Updated the volume name and network name. 

* For deployment, create the below network in the server externally: 

1. `production-algocode-auth-service-network` 

