### PR TITLE
chore: producion docker volume and netwotk names are updated

### DIFF
--- a/src/docker/production/nginx/Dockerfile
+++ b/src/docker/production/nginx/Dockerfile
@@ -1,5 +1,6 @@
 
 # nginx is not used in production. nginx proxy manager is used. 
+# To test production in locally, use the Nginx config from dev.yml
 FROM nginx:1.24.0-alpine
 
 RUN rm /etc/nginx/conf.d/default.conf

--- a/src/production.yml
+++ b/src/production.yml
@@ -7,8 +7,8 @@ services:
       dockerfile: ./docker/production/django/Dockerfile
     image: api-image
     volumes: 
-      - algocode_production_auth_static_volume:/app/staticfiles
-      - algocode_production_auth_media_volume:/app/mediafiles 
+      - production_algocode_auth_static_volume:/app/staticfiles
+      - production_algocode_auth_media_volume:/app/mediafiles 
     env_file: 
       - ./.envs/.production/.django
       - ./.envs/.production/.postgres
@@ -17,7 +17,7 @@ services:
       - redis-for-celery
     command: /start  
     networks: 
-      - algocode-production-auth-service-network
+      - production-algocode-auth-service-network
 
   postgres: 
     build: 
@@ -25,49 +25,49 @@ services:
       dockerfile: ./docker/production/postgres/Dockerfile
     image: pg-image
     volumes: 
-      - algocode_production_auth_production_postgres_data:/var/lib/postgresql/data
-      - algocode_production_auth_production_postgres_data_backups:/backups
+      - production_algocode_auth_postgres_data:/var/lib/postgresql/data
+      - production_algocode_auth_postgres_data_backups:/backups
     env_file: 
       - ./.envs/.production/.postgres 
     networks: 
-      - algocode-production-auth-service-network
+      - production-algocode-auth-service-network
 
     
   redis-for-celery: 
     image: redis:7-alpine
     networks: 
-      - algocode-production-auth-service-network
+      - production-algocode-auth-service-network
 
   celery_worker:   # using anchor of api service. 
     <<: *api 
     image: celery-image
     command: /start-celeryworker
     networks: 
-      - algocode-production-auth-service-network
+      - production-algocode-auth-service-network
     
   flower: 
     <<: *api 
     image: flower-image
     command: /start-flower
     volumes: 
-      - algocode_production_auth_flower_data:/data
+      - production_algocode_auth_flower_data:/data
     ports: 
       - "5555:5555"
     networks: 
-      - algocode-production-auth-service-network
+      - production-algocode-auth-service-network
     
 
 # TODO create the network in the server. 
 networks: 
-  algocode-production-auth-service-network: 
+  production-algocode-auth-service-network: 
     external: true 
   
 
 volumes: 
-  algocode_production_auth_static_volume: {}
-  algocode_production_auth_media_volume: {}
-  algocode_production_auth_production_postgres_data: {}
-  algocode_production_auth_production_postgres_data_backups: {}
-  algocode_production_auth_flower_data: {}
+  production_algocode_auth_static_volume: {}
+  production_algocode_auth_media_volume: {}
+  production_algocode_auth_postgres_data: {}
+  production_algocode_auth_postgres_data_backups: {}
+  production_algocode_auth_flower_data: {}
   
   

--- a/src/proxy-manager-portainer.yml
+++ b/src/proxy-manager-portainer.yml
@@ -2,7 +2,7 @@
 # This compose file shold be run inside the server. 
 # docker compose for nginx reverse proxy and portainer. see nginx reverse proxy documentation for more advanced settings.  
 # create the network if already not created. 
-# copy the compose file in the specified dir in the server, and then run the compose file. 
+# copy the compose file in the specified dir in the server or in the /opt/create_a_dir cd to new_dir and then run the compose file. 
 # docker compose -p algocode_auth_service_monitor -f proxy-manager-portainer.yml up -d --remove-orphans 
 # NOTE: put the correct compose file name after -f flag. 
 
@@ -15,16 +15,16 @@ services:
       - "81:81"
       - "443:443"
     volumes:
-      - nginx_proxy_manager_data:/data
-      - nginx_letsencrypt_data:/etc/letsencrypt
+      - production_algocode_npm_data:/data  # npm nginx proxy manager
+      - production_algocode_npn_letsencrypt_data:/etc/letsencrypt
     networks:
-      - algocode-backend-auth-service-network
+      - production-algocode-auth-service-network
       
   portainer:
     image: portainer/portainer-ce:latest 
     privileged: true
     volumes:
-      - portainer_data:/data
+      - production_algocode_portainer_data:/data
       - /var/run/docker.sock:/var/run/docker.sock
     ports: 
       - "8000:8000"
@@ -32,16 +32,16 @@ services:
       - "9000:9000"
     restart: always
     networks:
-      - algocode-backend-auth-service-network
+      - production-algocode-auth-service-network
 
 
 
-# TODO Create the network in the server 
+# TODO Create the Network in the EC2 Server. WIthin this network, the Auth Service (production.yml) is Running. 
 networks:
-  algocode-backend-auth-service-network:
+  production-algocode-auth-service-network:
    external: true 
 
 volumes:
-  portainer_data: {}
-  nginx_proxy_manager_data: {}
-  nginx_letsencrypt_data: {}
+  production_algocode_portainer_data: {}
+  production_algocode_npm_data: {}
+  production_algocode_npn_letsencrypt_data: {}


### PR DESCRIPTION
* Updated the volume name and network name.

* For deployment, create the below network in the server externally:

1. `production-algocode-auth-service-network`