### PR TITLE
chore: the logging for development stage is removed from base settings and placed at the .dev settings.

### DIFF
--- a/src/algocode_backend/settings/base.py
+++ b/src/algocode_backend/settings/base.py
@@ -272,33 +272,3 @@ CORS_URLS_REGEX = r"^api/.*$"
 
 AUTH_USER_MODEL = "users.CustomUser"
 
-########################################################
-# logging
-
-LOGGING = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "formatters": {
-        "verbose": {
-            "format": "%(levelname)s %(name)-12s %(asctime)s %(module)s  %(process)d %(thread)d %(message)s "
-        }
-    },
-    "handlers": {
-        "console": {
-            "level": "DEBUG",
-            "class": "logging.StreamHandler",
-            "formatter": "verbose",
-        }
-    },
-    "root": {
-        "level": "INFO",
-        "handlers": ["console"],
-    },
-    # uncomment for django database query logs
-    # 'loggers': {
-    #     'django.db': {
-    #         'level': 'DEBUG',
-    #         'handlers': ['console'],
-    #     }
-    # }
-}

--- a/src/algocode_backend/settings/checklist.txt
+++ b/src/algocode_backend/settings/checklist.txt
@@ -1,10 +1,10 @@
-
+# 060624, Thursday, 07.00 am 
 
 Here's the checklist for the Production and Development environment if local run is hampered for configurations. 
 
 Although the development branch has the settings as per the Development stage, and the 
 main branch holds the configs for Production stage, still, if anything unexpected arises, check the checklist below. 
- 
+
 
 This is a general checklist, if anything goes wrong in terms of settings and configurations, 
 make sure to check this checklist depending on the stage:  Development or Production

--- a/src/algocode_backend/settings/checklist.txt
+++ b/src/algocode_backend/settings/checklist.txt
@@ -1,0 +1,44 @@
+
+
+Here's the checklist for the Production and Development environment if local run is hampered for configurations. 
+
+Although the development branch has the settings as per the Development stage, and the 
+main branch holds the configs for Production stage, still, if anything unexpected arises, check the checklist below. 
+ 
+
+This is a general checklist, if anything goes wrong in terms of settings and configurations, 
+make sure to check this checklist depending on the stage:  Development or Production
+
+
+A. Checklist for Development: Check if the configs of the below are correct. 
+
+i. settings/base.py: 
+        ENVIRONMENT_TYPE = ".dev"
+
+ii. algocode_backend/asgi.py: 
+        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "algocode_backend.settings.dev")
+
+iii. algocode_backend/wsgi.py: 
+        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "algocode_backend.settings.dev")
+
+iv. src/manage.py: 
+        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "algocode_backend.settings.dev")
+
+
+
+B. Checklist for Production: Check if the configs of the below are correct. 
+
+i. settings/base.py: 
+        ENVIRONMENT_TYPE = ".production"
+
+ii. algocode_backend/asgi.py: 
+        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "algocode_backend.settings.production")
+
+iii. algocode_backend/wsgi.py: 
+        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "algocode_backend.settings.production")
+
+iv. src/manage.py: 
+        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "algocode_backend.settings.production")
+
+v. The docker network should be externally created. Check if it exists: 
+        production-algocode-auth-service-network

--- a/src/algocode_backend/settings/dev.py
+++ b/src/algocode_backend/settings/dev.py
@@ -23,3 +23,35 @@ DOMAIN = env("EMAIL_DOMAIN")
 EMAIL_PORT = env("EMAIL_PORT")
 DEFAULT_FROM_EMAIL = "iammahboob.a@gmail.com"
 SITE_NAME = "Algocode Backend"
+
+
+########################################################
+# logging
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "verbose": {
+            "format": "%(levelname)s %(name)-12s %(asctime)s %(module)s  %(process)d %(thread)d %(message)s "
+        }
+    },
+    "handlers": {
+        "console": {
+            "level": "DEBUG",
+            "class": "logging.StreamHandler",
+            "formatter": "verbose",
+        }
+    },
+    "root": {
+        "level": "INFO",
+        "handlers": ["console"],
+    },
+    # uncomment for django database query logs
+    # 'loggers': {
+    #     'django.db': {
+    #         'level': 'DEBUG',
+    #         'handlers': ['console'],
+    #     }
+    # }
+}


### PR DESCRIPTION
* A checklist.txt is also added at algocode_backend/settings/checklist.txt for a reference of configuration for dev and prod stage, this is a reference if anything related to config is breaking, check the checklist and make chaanges as per the checklist.

* Although the development branch holds the dev settings, but it is added for future reference that where does the dev and prod environment differ for resolving conflicts, if any. 